### PR TITLE
iPhone 14 Pro Frame Width

### DIFF
--- a/latest/offsets.json
+++ b/latest/offsets.json
@@ -350,7 +350,7 @@
     },
     "iPhone 14 Pro": {
       "offset": "+68+58",
-      "width": 1178
+      "width": 1179
     },
     "iPhone 14 Pro Max": {
       "offset": "+67+55",


### PR DESCRIPTION
I've reverted my previous commit. The previous screensize was correct due to the apple documentation.

I was not aware of that, because there is Bug in XCode 15.x that uses wrong dimensions when creating Screenshot with an UITest.
When taking screenshots manually the screenshots have the correct size according to the documentation.